### PR TITLE
bg(startupScript): ensure continued execution when dynamic updates fail

### DIFF
--- a/packer/start_vof.sh
+++ b/packer/start_vof.sh
@@ -288,8 +288,12 @@ main() {
   create_secrets_yml
   create_vof_supervisord_conf
   authenticate_service_account
-  authorize_redis_access_ips
-  authorize_database_access_networks
+  set +o errexit
+  set +o pipefail
+    authorize_redis_access_ips
+    authorize_database_access_networks
+  set -o errexit
+  set -o pipefail
   get_database_dump_file
   start_bugsnag
   start_app


### PR DESCRIPTION
- prevent startup script from exiting when dynamic updates to the
SQL instance and redis firewall are not successful. This happens
when simultaneous updates are done on the same instance.

[Fixes #157347094]

#### What does this PR do?

#### Description of Task to be completed?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)

#### Questions: